### PR TITLE
Support startTime, user locale, and add new fields

### DIFF
--- a/fitbit.js
+++ b/fitbit.js
@@ -39,12 +39,14 @@ var PROJECT_KEY_PROPERTY_NAME = "projectKey";
  * @const
  */
 var LOGGABLES = [ "activities/log/steps", "activities/log/distance",
+    "activities/log/floors",
     "activities/log/activeScore", "activities/log/activityCalories",
     "activities/log/calories", "foods/log/caloriesIn",
     "activities/log/minutesSedentary",
     "activities/log/minutesLightlyActive",
     "activities/log/minutesFairlyActive",
     "activities/log/minutesVeryActive", "sleep/timeInBed",
+    "sleep/minutesToFallAsleep", "sleep/startTime",
     "sleep/minutesAsleep", "sleep/minutesAwake", "sleep/awakeningsCount",
     "body/weight", "body/bmi", "body/fat" ];
 
@@ -100,7 +102,9 @@ function refreshTimeSeries() {
       var options = {
         "method" : "GET",
         "headers": {
-          "Authorization": "Bearer " + service.getAccessToken()
+          "Authorization": "Bearer " + service.getAccessToken(),
+          // Request the units based on the user's locale.
+          "Accept-Language": user.locale
         }
       };
 
@@ -146,7 +150,13 @@ function refreshTimeSeries() {
         // Insert Date into first column
         doc.getActiveSheet().getRange(row_index, 1).setValue(val["dateTime"]);
         // Insert value
-        doc.getActiveSheet().getRange(row_index, 2 + activity * 1.0).setValue(Number(val["value"]));
+        cell = doc.getActiveSheet().getRange(row_index, 2 + activity * 1.0);
+        if (title == "startTime") {
+          // values that are not numeric
+          cell.setValue(val["value"]);
+        } else {
+          cell.setValue(Number(val["value"]));
+        }
       }
     }
   }
@@ -425,17 +435,23 @@ function onInstall() {
 
 // Find the right row for a date.
 function findRow(date) {
+  // Zero out the hours / minutes / seconds / ms if set
+  date = date.setHours(0, 0, 0, 0);
   var doc = SpreadsheetApp.getActiveSpreadsheet();
   var cell = doc.getRange("A3");
 
+  var cell_date = new Date(cell.getValue())
+  cell_date.setHours(0, 0, 0, 0);
   // Find the first cell in first column which is either empty,
   // or has an equal or bigger date than the one we are looking for.
-  while ((cell.getValue() != "") && (cell.getValue() < date)) {
+  while ((cell.getValue() != "") && (cell_date < date)) {
     cell = cell.offset(1,0);
+    cell_date = new Date(cell.getValue())
+    cell_date.setHours(0, 0, 0, 0);
   }
   // If the cell we found has a newer date than ours, we need to
   // insert a new row right before that.
-  if (cell.getValue() > date) {
+  if (cell_date > date) {
     doc.insertRowBefore(cell.getRow())
   }
   // return only the number of the row.


### PR DESCRIPTION
Add new fields:
- floors
- minutesToFallAsleep
- sleep StartTime

Adds the user's locale to the request, which is now used by fitbit to convert the units to the user's locale. See: https://dev.fitbit.com/docs/basics/#units

Fix a bug where the date was not using a zero-hour causing it never to match across rows.
